### PR TITLE
Add basic logging support to GTFOBins MCP server.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,11 @@ COPY server.py .
 # Set unbuffered Python output
 ENV PYTHONUNBUFFERED=1
 
+#Create logs dir with proper permissions
+RUN mkdir -p /app/logs && chmod 755 /app/logs
+
+#Mountable volume for logs
+VOLUME /app/logs
+
 # Default command for MCP server
 CMD ["python", "/app/server.py"]

--- a/server.py
+++ b/server.py
@@ -20,7 +20,8 @@ from pydantic import AnyUrl
 import mcp.server.stdio
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(filename='/app/logs/gtfobins.log',level=logging.INFO, 
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 class GTFOBinsServer:


### PR DESCRIPTION
**Purpose:** This PR adds basic logging to /app/logs/gtfobins.log to track requests and errors, addressing the ‘Better error handling and logging’ contribution area.
**Changes:** Updated server.py with logging.basicConfig and added a VOLUME /app/logs to the Dockerfile.
**Testing:** Tested on a 2020 Intel MacBook Pro with Docker emulation; logs verified locally.
**Notes:** Draft PR—planning to refine error handling and test further.